### PR TITLE
Painter crashes on SetStrokeColor when still loading and navigating.

### DIFF
--- a/Painter.Forms.Shared/PainterViewRenderer.cs
+++ b/Painter.Forms.Shared/PainterViewRenderer.cs
@@ -55,7 +55,10 @@ namespace Painter.Forms.Droid
             set
             {
                 _strokeColor = value;
-                (Control as NativePainterView).StrokeColor = _strokeColor;
+                if(Control != null)
+                {
+                    (Control as NativePainterView).StrokeColor = _strokeColor;
+                }
             }
         }
 
@@ -69,7 +72,10 @@ namespace Painter.Forms.Droid
             set
             {
                 _finishedStrokeEvent = value;
-                (Control as NativePainterView).FinishedStrokeEvent = _finishedStrokeEvent;
+                if (Control != null)
+                {
+                    (Control as NativePainterView).FinishedStrokeEvent = _finishedStrokeEvent;
+                }
             }
         }
 
@@ -84,7 +90,10 @@ namespace Painter.Forms.Droid
             set
             {
                 _strokeThickness = value;
-                (Control as NativePainterView).StrokeThickness = _strokeThickness;
+                if (Control != null)
+                {
+                    (Control as NativePainterView).StrokeThickness = _strokeThickness;
+                }
             }
         }
         


### PR DESCRIPTION
I created a situation where i saved alot and then pressed the back button on accident. This crashed my app because painterview isn't there anymore, but still tries to set the Stroke Color to the Control.