### PR TITLE
Proposed fix for System.NullReferenceException crash

### DIFF
--- a/Painter.iOS/PainterView.cs
+++ b/Painter.iOS/PainterView.cs
@@ -162,18 +162,10 @@ namespace Painter.iOS
 			CurrentPathView.Opaque = false;
 			AddSubview(CurrentPathView);
 			BringSubviewToFront(CurrentPathView);
-
-			NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, HandleOrientationChange);
 		}
 
 		~PainterView()
 		{
-			NSNotificationCenter.DefaultCenter.RemoveObserver(this);
-		}
-
-		void HandleOrientationChange(NSNotification obj)
-		{
-			drawPath();
 		}
 
 		//Exports
@@ -315,7 +307,8 @@ namespace Painter.iOS
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
-
+			// Always redraw when laying out subviews. LayoutSubviews() is caused upon orientation change
+			drawPath();
 			ImageView.Frame = new CGRect(0, 0, Frame.Width, Frame.Height);
 			if (BackgroundImage != null)
 				BackgroundImage.Frame = new CGRect(0, 0, BackgroundImage.Image.Size.Width, BackgroundImage.Image.Size.Height);


### PR DESCRIPTION
Hi,

Thanks for this amazing library! I have found it very useful.

I ran into the following issue in Painter.iOS and wanted to share what I believe the solution might be as a PR:

```
System.NullReferenceException: Object reference not set to an instance of an object
Object reference not set to an instance of an object
PainterView.drawPath ()
PainterView.HandleOrientationChange (Foundation.NSNotification obj)
InternalNSNotificationHandler.Post (Foundation.NSNotification s) /Users/builder/data/lanes/5665/db807ec9/source/xamarin-macios/src/Foundation/NSNotificationCenter.cs:48
(wrapper managed-to-native) UIKit.UIApplication:UIApplicationMain (int,string[],intptr,intptr)
UIApplication.Main (System.String[] args, System.IntPtr principal, System.IntPtr delegate) /Users/builder/data/lanes/5665/db807ec9/source/xamarin-macios/src/UIKit/UIApplication.cs:79
UIApplication.Main (System.String[] args, System.String principalClassName, System.String delegateClassName) /Users/builder/data/lanes/5665/db807ec9/source/xamarin-macios/src/UIKit/UIApplication.cs:63
```

I believe removing the observer this way may correct the issue:
https://forums.xamarin.com/discussion/comment/95282/#Comment_95282

However, I made this change which is simpler which I believe should fix the issue as well. I tested rotation after applying this change and I see the redraw happen so it appears to work properly.

Thanks again!

Elijah